### PR TITLE
Readme and update test

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ An optional convenience step is to alias your SVG module in your myapp_web.ex fi
 ```elixir
 <%= Svg.render( "heroicons/menu" ) %>
 <%= Svg.render( "heroicons/user", class: "h-5 w-5 inline" ) %>
-<%= Svg.render( "heroicons/login", class: "h-5 w-5", phx_click: "action" )
-<%= Svg.render( "heroicons/logout", "@click": "alpine_action" )
+<%= Svg.render( "heroicons/login", class: "h-5 w-5", phx_click: "action" ) %>
+<%= Svg.render( "heroicons/logout", "@click": "alpine_action" ) %>
 ```
 
 ### Live reloading

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Adept.Svg.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   @url "https://github.com/adept-bits/adept_svg"
 
   def project do

--- a/test/adept_svg_test.exs
+++ b/test/adept_svg_test.exs
@@ -35,8 +35,7 @@ defmodule Adept.SvgTest do
         Adept.Svg.compile("test/svgs/more")
         |> Adept.Svg.compile("test/svgs/more")
       end)
-
-    assert log =~ "[warn]  SVG file:"
+    assert (log =~ "[warn]  SVG file:") || (log =~ "[warning] SVG file:")
     assert log =~ "overwrites existing svg: cube"
   end
 


### PR DESCRIPTION
- Fix the closing brackets in the readme examples
- Update the test that looks for log messages to work with the newer Logger style that spells out [warning] instead of just [warn]